### PR TITLE
Better output encoding

### DIFF
--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -106,8 +106,8 @@ def main():
         return_timestamps=ts,
     )
 
-    with open(args.transcript_path, "w") as fp:
-        json.dump(outputs, fp)
+    with open(args.transcript_path, "w", encoding="utf8") as fp:
+        json.dump(outputs, fp, ensure_ascii=False)
 
     print(
         f"Voila! Your file has been transcribed go check it out over here! {args.transcript_path}"


### PR DESCRIPTION
Since non-ascii characters are escaped like '\u123' in the output json files, imo it's more user friendly to use utf8 encoding.