### PR TITLE
Update python dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "setuptools>=68.2.2",
     "rich>=13.7.0",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.8,<=3.11"
 readme = "README.md"
 license = { text = "MIT" }
 


### PR DESCRIPTION
Optimum doesn't seem to work on 3.12, so we should prevent installation of this package on 3.12 for the time being