### PR TITLE
Unify json result and fix TypeError for None end-timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 
 .vscode/
+.idea/

--- a/src/insanely_fast_whisper/utils/diarization_pipeline.py
+++ b/src/insanely_fast_whisper/utils/diarization_pipeline.py
@@ -1,0 +1,31 @@
+import torch
+from pyannote.audio import Pipeline
+from rich.progress import Progress, TimeElapsedColumn, BarColumn, TextColumn
+
+from .diarize import post_process_segments_and_transcripts, diarize_audio, \
+    preprocess_inputs
+
+
+def diarize(args, outputs):
+    diarization_pipeline = Pipeline.from_pretrained(
+        checkpoint_path=args.diarization_model,
+        use_auth_token=args.hf_token,
+    )
+    diarization_pipeline.to(
+        torch.device("mps" if args.device_id == "mps" else f"cuda:{args.device_id}")
+    )
+
+    with Progress(
+            TextColumn("🤗 [progress.description]{task.description}"),
+            BarColumn(style="yellow1", pulse_style="white"),
+            TimeElapsedColumn(),
+    ) as progress:
+        progress.add_task("[yellow]Segmenting...", total=None)
+
+        inputs, diarizer_inputs = preprocess_inputs(inputs=args.file_name)
+
+        segments = diarize_audio(diarizer_inputs, diarization_pipeline)
+
+        return post_process_segments_and_transcripts(
+            segments, outputs["chunks"], group_by_speaker=False
+        )

--- a/src/insanely_fast_whisper/utils/result.py
+++ b/src/insanely_fast_whisper/utils/result.py
@@ -1,0 +1,15 @@
+from typing import TypedDict
+
+
+class JsonTranscriptionResult(TypedDict):
+    speakers: list
+    chunks: list
+    text: str
+
+
+def build_result(transcript, outputs) -> JsonTranscriptionResult:
+    return {
+        "speakers": transcript,
+        "chunks": outputs["chunks"],
+        "text": outputs["text"],
+    }


### PR DESCRIPTION
Unified JSON result so that it will be consistent across different modes (with and without speaker diarization). 
Proposed new JSON format:
```python
class JsonTranscriptionResult(TypedDict):
    speakers: list
    chunks: list
    text: str
```
If `hf_token` is not provided, the `speakers` list will be empty.

This PR also includes a bugfix for the following error:
```
    upto_idx = np.argmin(np.abs(end_timestamps - end_time))
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```