### PR TITLE
Fixed edge-case runtime error in diarization pipeline

### DIFF
--- a/src/insanely_fast_whisper/utils/diarize.py
+++ b/src/insanely_fast_whisper/utils/diarize.py
@@ -144,4 +144,7 @@ def post_process_segments_and_transcripts(new_segments, transcript, group_by_spe
         transcript = transcript[upto_idx + 1:]
         end_timestamps = end_timestamps[upto_idx + 1:]
 
+        if len(end_timestamps) == 0:
+            break 
+
     return segmented_preds


### PR DESCRIPTION
I keep getting the following error when transcribing longer audio files with diarization:

`ValueError: attempt to get argmin of an empty sequence `

Traced it back to an edge case in the diarization routine that occurs when post_process_segments_and_transcripts runs through all the end timestamps but still has a final segment left to iterate through.

This patch fixed it for me.