### PR TITLE
Add CPU device-id support

### DIFF
--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -19,7 +19,7 @@ parser.add_argument(
     required=False,
     default="0",
     type=str,
-    help='Device ID for your GPU. Just pass the device number when using CUDA, or "mps" for Macs with Apple Silicon. (default: "0")',
+    help='Device ID for your GPU. Just pass the device number when using CUDA, or "mps" for Macs with Apple Silicon or "cpu". (default: "0")',
 )
 parser.add_argument(
     "--transcript-path",
@@ -91,11 +91,13 @@ parser.add_argument(
 def main():
     args = parser.parse_args()
 
+    dtype = torch.float32 if args.device_id == "cpu" else torch.float16
+
     pipe = pipeline(
         "automatic-speech-recognition",
         model=args.model_name,
-        torch_dtype=torch.float16,
-        device="mps" if args.device_id == "mps" else f"cuda:{args.device_id}",
+        torch_dtype=dtype,
+        device=f"cuda:{args.device_id}" if args.device_id.isnumeric() else args.device_id,
         model_kwargs={"attn_implementation": "flash_attention_2"} if args.flash else {"attn_implementation": "sdpa"},
     )
 


### PR DESCRIPTION
Thank you for an easy to use CLI ❤️ 

Currently, if the library runs on CPU-only machine it fails with the following error:
```
RuntimeError: Found no NVIDIA driver on your system. Please check that you have an NVIDIA GPU and installed a driver from http://www.nvidia.com/Download/index.aspx
```
It makes sense to have the library optimised for GPU 👍🏻 However, do you think CPU option can also be valuable for debugging locally?

