### PR TITLE
Make it possible to install on Python 3.11.4 and later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "setuptools>=68.2.2",
     "rich>=13.7.0",
 ]
-requires-python = ">=3.8,<=3.11"
+requires-python = ">=3.8,<3.13"
 readme = "README.md"
 license = { text = "MIT" }
 


### PR DESCRIPTION
Restriction `<=3.11` prevents installation with Python 3.11.4 and later