### PR TITLE
Add Support and Enforce Constraints on Speaker Count Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,16 @@ The `insanely-fast-whisper` repo provides an all round support for running Whisp
                         Use Flash Attention 2. Read the FAQs to see how to install FA2 correctly. (default: False)
   --timestamp {chunk,word}
                         Whisper supports both chunked as well as word level timestamps. (default: chunk)
-  --hf_token
+  --hf_token TOKEN
                         Provide a hf.co/settings/token for Pyannote.audio to diarise the audio clips
+  --diarization_model DIARIZATION_MODEL
+                        Name of the pretrained model/ checkpoint to perform diarization. (default: pyannote/speaker-diarization)
+  --num-speakers NUM_SPEAKERS
+                        Specifies the exact number of speakers present in the audio file. Useful when the exact number of participants in the conversation is known. Must be at least 1. Cannot be used together with --min-speakers or --max-speakers. (default: None)
+  --min-speakers MIN_SPEAKERS
+                        Sets the minimum number of speakers that the system should consider during diarization. Must be at least 1. Cannot be used together with --num-speakers. Must be less than or equal to --max-speakers if both are specified. (default: None)
+  --max-speakers MAX_SPEAKERS
+                        Defines the maximum number of speakers that the system should consider in diarization. Must be at least 1. Cannot be used together with --num-speakers. Must be greater than or equal to --min-speakers if both are specified. (default: None)
 ```
 
 ## Frequently Asked Questions

--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -86,10 +86,46 @@ parser.add_argument(
     type=str,
     help="Name of the pretrained model/ checkpoint to perform diarization. (default: pyannote/speaker-diarization)",
 )
-
+parser.add_argument(
+    "--num-speakers",
+    required=False,
+    default=None,
+    type=int,
+    help="Specifies the exact number of speakers present in the audio file. Useful when the exact number of participants in the conversation is known. Must be at least 1. Cannot be used together with --min-speakers or --max-speakers. (default: None)",
+)
+parser.add_argument(
+    "--min-speakers",
+    required=False,
+    default=None,
+    type=int,
+    help="Sets the minimum number of speakers that the system should consider during diarization. Must be at least 1. Cannot be used together with --num-speakers. Must be less than or equal to --max-speakers if both are specified. (default: None)",
+)
+parser.add_argument(
+    "--max-speakers",
+    required=False,
+    default=None,
+    type=int,
+    help="Defines the maximum number of speakers that the system should consider in diarization. Must be at least 1. Cannot be used together with --num-speakers. Must be greater than or equal to --min-speakers if both are specified. (default: None)",
+)
 
 def main():
     args = parser.parse_args()
+
+    if args.num_speakers is not None and (args.min_speakers is not None or args.max_speakers is not None):
+        parser.error("--num-speakers cannot be used together with --min-speakers or --max-speakers.")
+
+    if args.num_speakers is not None and args.num_speakers < 1:
+        parser.error("--num-speakers must be at least 1.")
+
+    if args.min_speakers is not None and args.min_speakers < 1:
+        parser.error("--min-speakers must be at least 1.")
+
+    if args.max_speakers is not None and args.max_speakers < 1:
+        parser.error("--max-speakers must be at least 1.")
+
+    if args.min_speakers is not None and args.max_speakers is not None and args.min_speakers > args.max_speakers:
+        if args.min_speakers > args.max_speakers:
+            parser.error("--min-speakers cannot be greater than --max-speakers.")
 
     pipe = pipeline(
         "automatic-speech-recognition",

--- a/src/insanely_fast_whisper/utils/diarization_pipeline.py
+++ b/src/insanely_fast_whisper/utils/diarization_pipeline.py
@@ -24,7 +24,7 @@ def diarize(args, outputs):
 
         inputs, diarizer_inputs = preprocess_inputs(inputs=args.file_name)
 
-        segments = diarize_audio(diarizer_inputs, diarization_pipeline)
+        segments = diarize_audio(diarizer_inputs, diarization_pipeline, args.num_speakers, args.min_speakers, args.max_speakers)
 
         return post_process_segments_and_transcripts(
             segments, outputs["chunks"], group_by_speaker=False

--- a/src/insanely_fast_whisper/utils/diarize.py
+++ b/src/insanely_fast_whisper/utils/diarize.py
@@ -1,4 +1,3 @@
-import torch
 import requests
 import torch
 import numpy as np
@@ -59,9 +58,12 @@ def preprocess_inputs(inputs):
     return inputs, diarizer_inputs
 
 
-def diarize_audio(diarizer_inputs, diarization_pipeline):
+def diarize_audio(diarizer_inputs, diarization_pipeline, num_speakers, min_speakers, max_speakers):
     diarization = diarization_pipeline(
         {"waveform": diarizer_inputs, "sample_rate": 16000},
+        num_speakers=num_speakers,
+        min_speakers=min_speakers,
+        max_speakers=max_speakers,
     )
 
     segments = []


### PR DESCRIPTION
This pull request introduces new features and enhancements to the argument parsing logic in our Automatic Speech Recognition (ASR) tool, focusing on the handling of speaker count parameters (`--num-speakers`, `--min-speakers`, and `--max-speakers`). The additions enable users to specify the exact or range of speakers in the audio file directly through command-line arguments, improving the tool's flexibility and accuracy in speaker diarization.

Key Changes:
- Introduced support for `--num-speakers`, `--min-speakers`, and `--max-speakers` parameters, allowing users to define the speaker count more precisely.
- Implemented constraints to ensure `--num-speakers` is specified as a positive integer greater than 0.
- Enforced exclusive use of `--num-speakers` with either `--min-speakers` or `--max-speakers` to maintain logical parameter usage.
- Ensured that `--min-speakers` and `--max-speakers` are specified as integers greater than or equal to 1, and `--min-speakers` cannot exceed `--max-speakers`.

These updates enhance the ASR tool by providing more control over diarization processes and ensuring that users can specify speaker counts accurately and intuitively. The constraints prevent common misconfigurations and improve the overall user experience.
