### PR TITLE
Normalize CLI Argument Format for Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `insanely-fast-whisper` repo provides an all round support for running Whisp
                         Use Flash Attention 2. Read the FAQs to see how to install FA2 correctly. (default: False)
   --timestamp {chunk,word}
                         Whisper supports both chunked as well as word level timestamps. (default: chunk)
-  --hf_token TOKEN
+  --hf-token HF_TOKEN
                         Provide a hf.co/settings/token for Pyannote.audio to diarise the audio clips
   --diarization_model DIARIZATION_MODEL
                         Name of the pretrained model/ checkpoint to perform diarization. (default: pyannote/speaker-diarization)

--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -73,7 +73,7 @@ parser.add_argument(
     help="Whisper supports both chunked as well as word level timestamps. (default: chunk)",
 )
 parser.add_argument(
-    "--hf_token",
+    "--hf-token",
     required=False,
     default="no_token",
     type=str,


### PR DESCRIPTION
## Summary

This PR introduces a change to the CLI argument format by replacing `--hf_token` with `--hf-token`. This adjustment ensures consistency across the tool's interface, as all other parameters follow the hyphenated (-) format rather than using underscores (_). This inconsistency can potentially lead to user confusion and a slight deviation from common CLI practices.

## Changes and Impact

- The `--hf_token` parameter has been updated to `--hf-token` across the codebase.
- This modification introduces a breaking change, requiring users to adapt their scripts and command-line usage to accommodate the new argument format.
