### PR TITLE
Argument to allow CPU usage for diarization (to allow for low memory systems)

### DIFF
--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -107,7 +107,13 @@ parser.add_argument(
     type=int,
     help="Defines the maximum number of speakers that the system should consider in diarization. Must be at least 1. Cannot be used together with --num-speakers. Must be greater than or equal to --min-speakers if both are specified. (default: None)",
 )
-
+parser.add_argument(
+    "--diarize-CPU",
+    required=False,
+    default=None,
+    type=int,
+    help="TODO",
+)
 def main():
     args = parser.parse_args()
 

--- a/src/insanely_fast_whisper/utils/diarization_pipeline.py
+++ b/src/insanely_fast_whisper/utils/diarization_pipeline.py
@@ -11,8 +11,15 @@ def diarize(args, outputs):
         checkpoint_path=args.diarization_model,
         use_auth_token=args.hf_token,
     )
+    torchDevice = None
+    if args.device_id == "mps":
+        torchDevice = "mps"
+    elif args.diarize_CPU == 1:
+        torchDevice = "cpu"
+    else:
+        torchDevice = f"cuda:{args.device_id}"
     diarization_pipeline.to(
-        torch.device("mps" if args.device_id == "mps" else f"cuda:{args.device_id}")
+        torch.device(torchDevice)
     )
 
     with Progress(


### PR DESCRIPTION
Adding `--diarize-CPU 1` uses CPU for diarization process rather than CUDA - Useful for low memory systems where batch size or smaller model can be used for transcription, but not enough memory for diarization