### PR TITLE
remove python 3.12 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Install `insanely-fast-whisper` with `pipx` (`pip install pipx` or `brew install
 ```bash
 pipx install insanely-fast-whisper
 ```
-*Note: Due to a dependency on [`onnxruntime`, Python 3.12 is currently not supported](https://github.com/microsoft/onnxruntime/issues/17842). You can force a Python version (e.g. 3.11) by adding `--python python3.11` to the command.*
 
 ⚠️ If you have python 3.11.XX installed, `pipx` may parse the version incorrectly and install a very old version of `insanely-fast-whisper` without telling you (version `0.0.8`, which won't work anymore with the current `BetterTransformers`). In that case, you can install the latest version by passing `--ignore-requires-python` to `pip`:
 


### PR DESCRIPTION
the linked issue (https://github.com/microsoft/onnxruntime/issues/17842) is closed, and i was able to install on macOS with python3.12.

```
❯ python3 -V
Python 3.12.2
```