### PR TITLE
Include Parakeet MLX dependencies and detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ An opinionated CLI to transcribe Audio files w/ Whisper on-device! Powered by �
 pipx install insanely-fast-whisper==0.0.15 --force
 ```
 
+If you are on macOS and want to use the MLX backend, install the optional dependencies with:
+
+```
+pipx install 'insanely-fast-whisper[mac]' --force
+```
+
+The `mac` extra bundles Apple’s MLX runtime, the MLX Whisper bindings, and pulls the Parakeet speech models directly from the
+[mlx-parakeet](https://github.com/ml-explore/mlx-parakeet) repository so you can switch between `--mlx-model whisper` and
+`--mlx-model parakeet`.
+
 <p align="center">
 <img src="https://huggingface.co/datasets/reach-vb/random-images/resolve/main/insanely-fast-whisper-img.png" width="615" height="308">
 </p>
@@ -44,7 +54,7 @@ pipx install insanely-fast-whisper
 pipx install insanely-fast-whisper --force --pip-args="--ignore-requires-python"
 ```
 
-If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`.
+If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`. On macOS you can add the optional extras with `pip install "insanely-fast-whisper[mac]"` to grab both the MLX Whisper and Parakeet backends.
 
 
 Run inference from any path on your computer:
@@ -52,7 +62,7 @@ Run inference from any path on your computer:
 ```bash
 insanely-fast-whisper --file-name <filename or URL>
 ```
-*Note: if you are running on macOS, you also need to add `--device-id mps` flag.*
+*Note: on macOS install the MLX extras so the CLI can default to the MLX backend. Use `--backend transformers` together with `--device-id mps` if you prefer the Hugging Face pipeline on Metal.*
 
 🔥 You can run [Whisper-large-v3](https://huggingface.co/openai/whisper-large-v3) w/ [Flash Attention 2](https://github.com/Dao-AILab/flash-attention) from this CLI too:
 
@@ -73,7 +83,10 @@ pipx run insanely-fast-whisper --file-name <filename or URL>
 ```
 
 > [!NOTE]
-> The CLI is highly opinionated and only works on NVIDIA GPUs & Mac. Make sure to check out the defaults and the list of options you can play around with to maximise your transcription throughput. Run `insanely-fast-whisper --help` or `pipx run insanely-fast-whisper --help` to get all the CLI arguments along with their defaults. 
+> The CLI is highly opinionated and only works on NVIDIA GPUs & Mac. Make sure to check out the defaults and the list of options you can play around with to maximise your transcription throughput. Run `insanely-fast-whisper --help` or `pipx run insanely-fast-whisper --help` to get all the CLI arguments along with their defaults.
+
+> [!TIP]
+> When choosing `--mlx-model parakeet`, supply an MLX-compatible Parakeet checkpoint through `--model-name` following the guidance from the MLX Parakeet project.
 
 
 ## CLI Options
@@ -85,10 +98,14 @@ The `insanely-fast-whisper` repo provides an all round support for running Whisp
                         Path or URL to the audio file to be transcribed.
   --device-id DEVICE_ID
                         Device ID for your GPU. Just pass the device number when using CUDA, or "mps" for Macs with Apple Silicon. (default: "0")
+  --backend {auto,transformers,mlx}
+                        Backend to use: transformers, mlx, or auto to pick based on the environment. (default: auto)
   --transcript-path TRANSCRIPT_PATH
                         Path to save the transcription output. (default: output.json)
   --model-name MODEL_NAME
                         Name of the pretrained model/ checkpoint to perform ASR. (default: openai/whisper-large-v3)
+  --mlx-model {whisper,parakeet}
+                        When using the MLX backend, choose between Whisper or Parakeet checkpoints. (default: whisper)
   --task {transcribe,translate}
                         Task to perform: transcribe or translate to another language. (default: transcribe)
   --language LANGUAGE   

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ If you are on macOS and want to use the MLX backend, install the optional depend
 pipx install 'insanely-fast-whisper[mac]' --force
 ```
 
-The `mac` extra bundles Apple’s MLX runtime, the MLX Whisper bindings, and pulls the Parakeet speech models directly from the
-[mlx-parakeet](https://github.com/ml-explore/mlx-parakeet) repository so you can switch between `--mlx-model whisper` and
-`--mlx-model parakeet`.
+The `mac` extra bundles Apple’s MLX runtime and the MLX Whisper bindings. Parakeet support expects an `mlx_parakeet` Python
+package on your system; install it separately before selecting `--mlx-model parakeet`.
 
 <p align="center">
 <img src="https://huggingface.co/datasets/reach-vb/random-images/resolve/main/insanely-fast-whisper-img.png" width="615" height="308">
@@ -54,7 +53,7 @@ pipx install insanely-fast-whisper
 pipx install insanely-fast-whisper --force --pip-args="--ignore-requires-python"
 ```
 
-If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`. On macOS you can add the optional extras with `pip install "insanely-fast-whisper[mac]"` to grab both the MLX Whisper and Parakeet backends.
+If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`. On macOS you can add the optional extras with `pip install "insanely-fast-whisper[mac]"` to grab the MLX Whisper backend (install `mlx_parakeet` manually if you want the Parakeet flow).
 
 
 Run inference from any path on your computer:
@@ -86,7 +85,8 @@ pipx run insanely-fast-whisper --file-name <filename or URL>
 > The CLI is highly opinionated and only works on NVIDIA GPUs & Mac. Make sure to check out the defaults and the list of options you can play around with to maximise your transcription throughput. Run `insanely-fast-whisper --help` or `pipx run insanely-fast-whisper --help` to get all the CLI arguments along with their defaults.
 
 > [!TIP]
-> When choosing `--mlx-model parakeet`, supply an MLX-compatible Parakeet checkpoint through `--model-name` following the guidance from the MLX Parakeet project.
+> When choosing `--mlx-model parakeet`, supply an MLX-compatible Parakeet checkpoint through `--model-name` and ensure the
+> `mlx_parakeet` package is available in your environment.
 
 
 ## CLI Options

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If you are on macOS and want to use the MLX backend, install the optional depend
 pipx install 'insanely-fast-whisper[mac]' --force
 ```
 
-The `mac` extra bundles Apple’s MLX runtime and the MLX Whisper bindings. Parakeet support expects an `mlx_parakeet` Python
-package on your system; install it separately before selecting `--mlx-model parakeet`.
+The `mac` extra bundles Apple’s MLX runtime plus the MLX Whisper and Parakeet bindings, so `pipx install 'insanely-fast-whisper[mac]'`
+sets up both MLX speech backends automatically.
 
 <p align="center">
 <img src="https://huggingface.co/datasets/reach-vb/random-images/resolve/main/insanely-fast-whisper-img.png" width="615" height="308">
@@ -53,7 +53,7 @@ pipx install insanely-fast-whisper
 pipx install insanely-fast-whisper --force --pip-args="--ignore-requires-python"
 ```
 
-If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`. On macOS you can add the optional extras with `pip install "insanely-fast-whisper[mac]"` to grab the MLX Whisper backend (install `mlx_parakeet` manually if you want the Parakeet flow).
+If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`. On macOS you can add the optional extras with `pip install "insanely-fast-whisper[mac]"` to grab the MLX Whisper and Parakeet backends automatically.
 
 
 Run inference from any path on your computer:
@@ -85,8 +85,7 @@ pipx run insanely-fast-whisper --file-name <filename or URL>
 > The CLI is highly opinionated and only works on NVIDIA GPUs & Mac. Make sure to check out the defaults and the list of options you can play around with to maximise your transcription throughput. Run `insanely-fast-whisper --help` or `pipx run insanely-fast-whisper --help` to get all the CLI arguments along with their defaults.
 
 > [!TIP]
-> When choosing `--mlx-model parakeet`, supply an MLX-compatible Parakeet checkpoint through `--model-name` and ensure the
-> `mlx_parakeet` package is available in your environment.
+> When choosing `--mlx-model parakeet`, supply an MLX-compatible Parakeet checkpoint through `--model-name`. The mac extra installs the required `parakeet-mlx` bindings for you.
 
 
 ## CLI Options

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ pipx install 'insanely-fast-whisper[mac]' --force
 ```
 
 The `mac` extra bundles Apple’s MLX runtime plus the MLX Whisper and Parakeet bindings, so `pipx install 'insanely-fast-whisper[mac]'`
-sets up both MLX speech backends automatically.
+sets up both MLX speech backends automatically. These wheels target Python 3.10 and newer; if you use an older interpreter the
+extra installs but skips the MLX packages, so upgrade Python to leverage the MLX backend fully.
 
 <p align="center">
 <img src="https://huggingface.co/datasets/reach-vb/random-images/resolve/main/insanely-fast-whisper-img.png" width="615" height="308">
@@ -53,7 +54,7 @@ pipx install insanely-fast-whisper
 pipx install insanely-fast-whisper --force --pip-args="--ignore-requires-python"
 ```
 
-If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`. On macOS you can add the optional extras with `pip install "insanely-fast-whisper[mac]"` to grab the MLX Whisper and Parakeet backends automatically.
+If you're installing with `pip`, you can pass the argument directly: `pip install insanely-fast-whisper --ignore-requires-python`. On macOS you can add the optional extras with `pip install "insanely-fast-whisper[mac]"` (requires Python 3.10+) to grab the MLX Whisper and Parakeet backends automatically.
 
 
 Run inference from any path on your computer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ license = { text = "MIT" }
 mac = [
     "mlx>=0.29.0; sys_platform == 'darwin'",
     "mlx-whisper>=0.4.0; sys_platform == 'darwin'",
+    "parakeet-mlx>=0.4.0; sys_platform == 'darwin'",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ license = { text = "MIT" }
 
 [project.optional-dependencies]
 mac = [
-    "mlx>=0.29.0; sys_platform == 'darwin'",
-    "mlx-whisper>=0.4.0; sys_platform == 'darwin'",
-    "parakeet-mlx>=0.4.0; sys_platform == 'darwin'",
+    "mlx>=0.29.0; sys_platform == 'darwin' and python_version >= '3.10'",
+    "mlx-whisper>=0.4.0; sys_platform == 'darwin' and python_version >= '3.10'",
+    "parakeet-mlx>=0.4.0; sys_platform == 'darwin' and python_version >= '3.10'",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ license = { text = "MIT" }
 mac = [
     "mlx>=0.29.0; sys_platform == 'darwin'",
     "mlx-whisper>=0.4.0; sys_platform == 'darwin'",
-    "mlx-parakeet @ git+https://github.com/ml-explore/mlx-parakeet; sys_platform == 'darwin'",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,14 @@ readme = "README.md"
 license = { text = "MIT" }
 
 
+[project.optional-dependencies]
+mac = [
+    "mlx>=0.29.0; sys_platform == 'darwin'",
+    "mlx-whisper>=0.4.0; sys_platform == 'darwin'",
+    "mlx-parakeet @ git+https://github.com/ml-explore/mlx-parakeet; sys_platform == 'darwin'",
+]
+
+
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"

--- a/src/insanely_fast_whisper/backends.py
+++ b/src/insanely_fast_whisper/backends.py
@@ -1,0 +1,230 @@
+"""Backend helpers for insanely-fast-whisper."""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import platform
+from contextlib import contextmanager
+from typing import Dict, Iterable, List, Optional
+
+
+class BackendSelectionError(RuntimeError):
+    """Raised when an invalid backend is requested."""
+
+
+class BackendDependencyError(RuntimeError):
+    """Raised when optional backend dependencies are missing."""
+
+
+def is_mlx_available() -> bool:
+    """Return True when at least one MLX speech package can be located."""
+
+    return any(
+        importlib.util.find_spec(package) is not None  # type: ignore[attr-defined]
+        for package in ("mlx_whisper", "mlx_parakeet")
+    )
+
+
+def select_backend(
+    *,
+    device_id: str,
+    requested_backend: str,
+    platform_name: Optional[str] = None,
+    mlx_available: Optional[bool] = None,
+) -> str:
+    """Resolve the backend that should be used for transcription."""
+
+    if platform_name is None:
+        platform_name = platform.system()
+
+    if requested_backend == "transformers":
+        return "transformers"
+
+    if requested_backend == "mlx":
+        if platform_name != "Darwin":
+            raise BackendSelectionError("The MLX backend is only supported on macOS.")
+        if not (mlx_available if mlx_available is not None else is_mlx_available()):
+            raise BackendSelectionError(
+                "The MLX backend requires the optional MLX dependencies. "
+                "Install insanely-fast-whisper[mac]."
+            )
+        return "mlx"
+
+    # Auto mode
+    if device_id != "mps":
+        return "transformers"
+
+    if platform_name != "Darwin":
+        return "transformers"
+
+    available = mlx_available if mlx_available is not None else is_mlx_available()
+    if not available:
+        raise BackendSelectionError(
+            "Detected macOS/Metal but the MLX dependencies are missing. "
+            "Install insanely-fast-whisper[mac] or select --backend transformers."
+        )
+
+    return "mlx"
+
+
+@contextmanager
+def _progress(task_description: str):
+    from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
+
+    with Progress(
+        TextColumn("🤗 [progress.description]{task.description}"),
+        BarColumn(style="yellow1", pulse_style="white"),
+        TimeElapsedColumn(),
+    ) as progress:
+        progress.add_task(task_description, total=None)
+        yield
+
+
+def _import_mlx_module(module_name: str):
+    try:
+        return importlib.import_module(module_name)
+    except (ImportError, OSError) as exc:  # pragma: no cover - exercised in real envs
+        raise BackendDependencyError(
+            "The MLX backend requires optional dependencies. Install "
+            "insanely-fast-whisper[mac] and ensure the '{}' package is available.".format(module_name)
+        ) from exc
+
+
+def _segments_to_chunks(segments: Iterable[Dict], timestamp_mode: str) -> List[Dict]:
+    chunks: List[Dict] = []
+
+    if timestamp_mode == "word":
+        for segment in segments:
+            for word in segment.get("words") or []:
+                start = word.get("start")
+                end = word.get("end")
+                if start is None or end is None:
+                    continue
+                text = word.get("word") or word.get("text", "")
+                chunks.append({"timestamp": (start, end), "text": text})
+        if chunks:
+            return chunks
+
+    for segment in segments:
+        start = segment.get("start")
+        end = segment.get("end")
+        if start is None or end is None:
+            continue
+        chunks.append({"timestamp": (start, end), "text": segment.get("text", "")})
+
+    return chunks
+
+
+def run_transformers_backend(
+    *,
+    audio_path: str,
+    model_name: str,
+    device_id: str,
+    batch_size: int,
+    task: str,
+    language: Optional[str],
+    timestamp: str,
+    flash: bool,
+) -> Dict:
+    from transformers import pipeline
+    import torch
+
+    attn_impl = "flash_attention_2" if flash else "sdpa"
+    ts = "word" if timestamp == "word" else True
+
+    generate_kwargs: Dict[str, str] = {"task": task}
+    if language:
+        generate_kwargs["language"] = language
+
+    if model_name.split(".")[-1] == "en":
+        generate_kwargs.pop("task", None)
+
+    with _progress("[yellow]Transcribing with Transformers..."):
+        pipe = pipeline(
+            "automatic-speech-recognition",
+            model=model_name,
+            torch_dtype=torch.float16,
+            device="mps" if device_id == "mps" else f"cuda:{device_id}",
+            model_kwargs={"attn_implementation": attn_impl},
+        )
+
+        outputs = pipe(
+            audio_path,
+            chunk_length_s=30,
+            batch_size=batch_size,
+            generate_kwargs=generate_kwargs,
+            return_timestamps=ts,
+        )
+
+    if device_id == "mps":
+        torch.mps.empty_cache()
+
+    if "chunks" not in outputs:
+        chunks = _segments_to_chunks(outputs.get("segments", []), timestamp)
+        outputs["chunks"] = chunks
+
+    return outputs
+
+
+def _resolve_whisper_repo(model_name: str) -> str:
+    if model_name == "openai/whisper-large-v3":
+        return "mlx-community/whisper-large-v3"
+    return model_name
+
+
+def _resolve_parakeet_repo(model_name: str) -> str:
+    if model_name == "openai/whisper-large-v3":
+        raise BackendSelectionError(
+            "Specify --model-name with an MLX-compatible Parakeet checkpoint when using --mlx-model parakeet."
+        )
+    return model_name
+
+
+def run_mlx_backend(
+    *,
+    audio_path: str,
+    model_name: str,
+    task: str,
+    language: Optional[str],
+    timestamp: str,
+    batch_size: int,
+    mlx_model: str,
+) -> Dict:
+    decode_options: Dict[str, str] = {"task": task}
+    if language:
+        decode_options["language"] = language
+
+    if mlx_model == "whisper":
+        module = _import_mlx_module("mlx_whisper")
+        repo = _resolve_whisper_repo(model_name)
+        if repo.split(".")[-1] == "en":
+            decode_options.pop("task", None)
+
+        with _progress("[yellow]Transcribing with MLX Whisper..."):
+            result = module.transcribe(
+                audio_path,
+                path_or_hf_repo=repo,
+                word_timestamps=timestamp == "word",
+                verbose=False,
+                **decode_options,
+            )
+
+    elif mlx_model == "parakeet":
+        module = _import_mlx_module("mlx_parakeet")
+        repo = _resolve_parakeet_repo(model_name)
+        if repo.split(".")[-1] == "en":
+            decode_options.pop("task", None)
+
+        with _progress("[yellow]Transcribing with MLX Parakeet..."):
+            result = module.transcribe(
+                audio_path,
+                path_or_hf_repo=repo,
+                word_timestamps=timestamp == "word",
+                verbose=False,
+                **decode_options,
+            )
+    else:
+        raise BackendSelectionError(f"Unknown MLX model '{mlx_model}'.")
+
+    chunks = _segments_to_chunks(result.get("segments", []), timestamp)
+    return {"text": result.get("text", ""), "chunks": chunks}

--- a/src/insanely_fast_whisper/backends.py
+++ b/src/insanely_fast_whisper/backends.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterable, List, Optional
 
 MLX_MODULES = {
     "whisper": "mlx_whisper",
-    "parakeet": "mlx_parakeet",
+    "parakeet": "parakeet_mlx",
 }
 
 

--- a/src/insanely_fast_whisper/backends.py
+++ b/src/insanely_fast_whisper/backends.py
@@ -1,28 +1,30 @@
-"""Backend helpers for insanely-fast-whisper."""
+"""Minimal backend helpers for insanely-fast-whisper."""
 from __future__ import annotations
 
 import importlib
 import importlib.util
 import platform
-from contextlib import contextmanager
 from typing import Dict, Iterable, List, Optional
 
 
+MLX_MODULES = {
+    "whisper": "mlx_whisper",
+    "parakeet": "mlx_parakeet",
+}
+
+
 class BackendSelectionError(RuntimeError):
-    """Raised when an invalid backend is requested."""
+    """Raised when a backend cannot be used in the current environment."""
 
 
 class BackendDependencyError(RuntimeError):
-    """Raised when optional backend dependencies are missing."""
+    """Raised when an optional backend dependency is missing."""
 
 
 def is_mlx_available() -> bool:
-    """Return True when at least one MLX speech package can be located."""
+    """Return True when any MLX speech package can be imported."""
 
-    return any(
-        importlib.util.find_spec(package) is not None  # type: ignore[attr-defined]
-        for package in ("mlx_whisper", "mlx_parakeet")
-    )
+    return any(importlib.util.find_spec(module) is not None for module in MLX_MODULES.values())
 
 
 def select_backend(
@@ -32,10 +34,10 @@ def select_backend(
     platform_name: Optional[str] = None,
     mlx_available: Optional[bool] = None,
 ) -> str:
-    """Resolve the backend that should be used for transcription."""
+    """Resolve the backend for transcription based on CLI flags and environment."""
 
-    if platform_name is None:
-        platform_name = platform.system()
+    platform_name = platform_name or platform.system()
+    available = mlx_available if mlx_available is not None else is_mlx_available()
 
     if requested_backend == "transformers":
         return "transformers"
@@ -43,51 +45,21 @@ def select_backend(
     if requested_backend == "mlx":
         if platform_name != "Darwin":
             raise BackendSelectionError("The MLX backend is only supported on macOS.")
-        if not (mlx_available if mlx_available is not None else is_mlx_available()):
+        if not available:
             raise BackendSelectionError(
-                "The MLX backend requires the optional MLX dependencies. "
-                "Install insanely-fast-whisper[mac]."
+                "The MLX backend requires the optional MLX dependencies. Install insanely-fast-whisper[mac]."
             )
         return "mlx"
 
-    # Auto mode
-    if device_id != "mps":
-        return "transformers"
-
-    if platform_name != "Darwin":
-        return "transformers"
-
-    available = mlx_available if mlx_available is not None else is_mlx_available()
-    if not available:
+    if device_id == "mps" and platform_name == "Darwin":
+        if available:
+            return "mlx"
         raise BackendSelectionError(
-            "Detected macOS/Metal but the MLX dependencies are missing. "
-            "Install insanely-fast-whisper[mac] or select --backend transformers."
+            "Detected macOS/Metal but the MLX dependencies are missing. Install insanely-fast-whisper[mac] "
+            "or select --backend transformers."
         )
 
-    return "mlx"
-
-
-@contextmanager
-def _progress(task_description: str):
-    from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
-
-    with Progress(
-        TextColumn("🤗 [progress.description]{task.description}"),
-        BarColumn(style="yellow1", pulse_style="white"),
-        TimeElapsedColumn(),
-    ) as progress:
-        progress.add_task(task_description, total=None)
-        yield
-
-
-def _import_mlx_module(module_name: str):
-    try:
-        return importlib.import_module(module_name)
-    except (ImportError, OSError) as exc:  # pragma: no cover - exercised in real envs
-        raise BackendDependencyError(
-            "The MLX backend requires optional dependencies. Install "
-            "insanely-fast-whisper[mac] and ensure the '{}' package is available.".format(module_name)
-        ) from exc
+    return "transformers"
 
 
 def _segments_to_chunks(segments: Iterable[Dict], timestamp_mode: str) -> List[Dict]:
@@ -139,45 +111,29 @@ def run_transformers_backend(
     if model_name.split(".")[-1] == "en":
         generate_kwargs.pop("task", None)
 
-    with _progress("[yellow]Transcribing with Transformers..."):
-        pipe = pipeline(
-            "automatic-speech-recognition",
-            model=model_name,
-            torch_dtype=torch.float16,
-            device="mps" if device_id == "mps" else f"cuda:{device_id}",
-            model_kwargs={"attn_implementation": attn_impl},
-        )
+    pipe = pipeline(
+        "automatic-speech-recognition",
+        model=model_name,
+        torch_dtype=torch.float16,
+        device="mps" if device_id == "mps" else f"cuda:{device_id}",
+        model_kwargs={"attn_implementation": attn_impl},
+    )
 
-        outputs = pipe(
-            audio_path,
-            chunk_length_s=30,
-            batch_size=batch_size,
-            generate_kwargs=generate_kwargs,
-            return_timestamps=ts,
-        )
+    outputs = pipe(
+        audio_path,
+        chunk_length_s=30,
+        batch_size=batch_size,
+        generate_kwargs=generate_kwargs,
+        return_timestamps=ts,
+    )
 
     if device_id == "mps":
         torch.mps.empty_cache()
 
     if "chunks" not in outputs:
-        chunks = _segments_to_chunks(outputs.get("segments", []), timestamp)
-        outputs["chunks"] = chunks
+        outputs["chunks"] = _segments_to_chunks(outputs.get("segments", []), timestamp)
 
     return outputs
-
-
-def _resolve_whisper_repo(model_name: str) -> str:
-    if model_name == "openai/whisper-large-v3":
-        return "mlx-community/whisper-large-v3"
-    return model_name
-
-
-def _resolve_parakeet_repo(model_name: str) -> str:
-    if model_name == "openai/whisper-large-v3":
-        raise BackendSelectionError(
-            "Specify --model-name with an MLX-compatible Parakeet checkpoint when using --mlx-model parakeet."
-        )
-    return model_name
 
 
 def run_mlx_backend(
@@ -187,44 +143,44 @@ def run_mlx_backend(
     task: str,
     language: Optional[str],
     timestamp: str,
-    batch_size: int,
     mlx_model: str,
 ) -> Dict:
+    module_name = MLX_MODULES.get(mlx_model)
+    if module_name is None:
+        raise BackendSelectionError(f"Unknown MLX model '{mlx_model}'.")
+
+    try:
+        module = importlib.import_module(module_name)
+    except (ImportError, OSError) as exc:  # pragma: no cover - exercised in real envs
+        raise BackendDependencyError(
+            "The MLX backend requires optional dependencies. Install insanely-fast-whisper[mac] and ensure the "
+            f"'{module_name}' package is available."
+        ) from exc
+
+    if mlx_model == "whisper" and model_name == "openai/whisper-large-v3":
+        repo = "mlx-community/whisper-large-v3"
+    elif mlx_model == "parakeet":
+        if model_name == "openai/whisper-large-v3":
+            raise BackendSelectionError(
+                "Specify --model-name with an MLX-compatible Parakeet checkpoint when using --mlx-model parakeet."
+            )
+        repo = model_name
+    else:
+        repo = model_name
+
     decode_options: Dict[str, str] = {"task": task}
     if language:
         decode_options["language"] = language
 
-    if mlx_model == "whisper":
-        module = _import_mlx_module("mlx_whisper")
-        repo = _resolve_whisper_repo(model_name)
-        if repo.split(".")[-1] == "en":
-            decode_options.pop("task", None)
+    if repo.split(".")[-1] == "en":
+        decode_options.pop("task", None)
 
-        with _progress("[yellow]Transcribing with MLX Whisper..."):
-            result = module.transcribe(
-                audio_path,
-                path_or_hf_repo=repo,
-                word_timestamps=timestamp == "word",
-                verbose=False,
-                **decode_options,
-            )
+    result = module.transcribe(
+        audio_path,
+        path_or_hf_repo=repo,
+        word_timestamps=timestamp == "word",
+        verbose=False,
+        **decode_options,
+    )
 
-    elif mlx_model == "parakeet":
-        module = _import_mlx_module("mlx_parakeet")
-        repo = _resolve_parakeet_repo(model_name)
-        if repo.split(".")[-1] == "en":
-            decode_options.pop("task", None)
-
-        with _progress("[yellow]Transcribing with MLX Parakeet..."):
-            result = module.transcribe(
-                audio_path,
-                path_or_hf_repo=repo,
-                word_timestamps=timestamp == "word",
-                verbose=False,
-                **decode_options,
-            )
-    else:
-        raise BackendSelectionError(f"Unknown MLX model '{mlx_model}'.")
-
-    chunks = _segments_to_chunks(result.get("segments", []), timestamp)
-    return {"text": result.get("text", ""), "chunks": chunks}
+    return {"text": result.get("text", ""), "chunks": _segments_to_chunks(result.get("segments", []), timestamp)}

--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -168,7 +168,6 @@ def main():
                 task=args.task,
                 language=language,
                 timestamp=args.timestamp,
-                batch_size=args.batch_size,
                 mlx_model=args.mlx_model,
             )
         except BackendDependencyError as exc:

--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -1,8 +1,15 @@
-import json
 import argparse
-from transformers import pipeline
-from rich.progress import Progress, TimeElapsedColumn, BarColumn, TextColumn
-import torch
+import json
+import platform
+
+from .backends import (
+    BackendDependencyError,
+    BackendSelectionError,
+    is_mlx_available,
+    run_mlx_backend,
+    run_transformers_backend,
+    select_backend,
+)
 
 from .utils.diarization_pipeline import diarize
 from .utils.result import build_result
@@ -20,6 +27,20 @@ parser.add_argument(
     default="0",
     type=str,
     help='Device ID for your GPU. Just pass the device number when using CUDA, or "mps" for Macs with Apple Silicon. (default: "0")',
+)
+parser.add_argument(
+    "--backend",
+    required=False,
+    default="auto",
+    choices=["auto", "transformers", "mlx"],
+    help="Backend to use: transformers, mlx, or auto to pick based on the environment. (default: auto)",
+)
+parser.add_argument(
+    "--mlx-model",
+    required=False,
+    default="whisper",
+    choices=["whisper", "parakeet"],
+    help="When using the MLX backend, choose between Whisper or Parakeet checkpoints. (default: whisper)",
 )
 parser.add_argument(
     "--transcript-path",
@@ -127,41 +148,41 @@ def main():
         if args.min_speakers > args.max_speakers:
             parser.error("--min-speakers cannot be greater than --max-speakers.")
 
-    pipe = pipeline(
-        "automatic-speech-recognition",
-        model=args.model_name,
-        torch_dtype=torch.float16,
-        device="mps" if args.device_id == "mps" else f"cuda:{args.device_id}",
-        model_kwargs={"attn_implementation": "flash_attention_2"} if args.flash else {"attn_implementation": "sdpa"},
-    )
-
-    if args.device_id == "mps":
-        torch.mps.empty_cache()
-    # elif not args.flash:
-        # pipe.model = pipe.model.to_bettertransformer()
-
-    ts = "word" if args.timestamp == "word" else True
-
     language = None if args.language == "None" else args.language
 
-    generate_kwargs = {"task": args.task, "language": language}
+    try:
+        backend = select_backend(
+            device_id=args.device_id,
+            requested_backend=args.backend,
+            platform_name=platform.system(),
+            mlx_available=is_mlx_available(),
+        )
+    except BackendSelectionError as exc:
+        parser.error(str(exc))
 
-    if args.model_name.split(".")[-1] == "en":
-        generate_kwargs.pop("task")
-
-    with Progress(
-        TextColumn("🤗 [progress.description]{task.description}"),
-        BarColumn(style="yellow1", pulse_style="white"),
-        TimeElapsedColumn(),
-    ) as progress:
-        progress.add_task("[yellow]Transcribing...", total=None)
-
-        outputs = pipe(
-            args.file_name,
-            chunk_length_s=30,
+    if backend == "mlx":
+        try:
+            outputs = run_mlx_backend(
+                audio_path=args.file_name,
+                model_name=args.model_name,
+                task=args.task,
+                language=language,
+                timestamp=args.timestamp,
+                batch_size=args.batch_size,
+                mlx_model=args.mlx_model,
+            )
+        except BackendDependencyError as exc:
+            parser.error(str(exc))
+    else:
+        outputs = run_transformers_backend(
+            audio_path=args.file_name,
+            model_name=args.model_name,
+            device_id=args.device_id,
             batch_size=args.batch_size,
-            generate_kwargs=generate_kwargs,
-            return_timestamps=ts,
+            task=args.task,
+            language=language,
+            timestamp=args.timestamp,
+            flash=args.flash,
         )
 
     if args.hf_token != "no_token":

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,174 @@
+import pathlib
+import sys
+import unittest
+from contextlib import nullcontext
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from insanely_fast_whisper import backends
+
+
+class AvailabilityTests(unittest.TestCase):
+    def test_is_mlx_available_when_whisper_installed(self):
+        with mock.patch("importlib.util.find_spec", side_effect=lambda name: object() if name == "mlx_whisper" else None):
+            self.assertTrue(backends.is_mlx_available())
+
+    def test_is_mlx_available_when_parakeet_installed(self):
+        with mock.patch("importlib.util.find_spec", side_effect=lambda name: object() if name == "mlx_parakeet" else None):
+            self.assertTrue(backends.is_mlx_available())
+
+    def test_is_mlx_unavailable_when_no_packages_found(self):
+        with mock.patch("importlib.util.find_spec", return_value=None):
+            self.assertFalse(backends.is_mlx_available())
+
+
+class SelectBackendTests(unittest.TestCase):
+    def test_auto_prefers_transformers_on_cuda(self):
+        choice = backends.select_backend(
+            device_id="0", requested_backend="auto", platform_name="Linux", mlx_available=False
+        )
+        self.assertEqual(choice, "transformers")
+
+    def test_auto_requires_mlx_packages_on_mac(self):
+        with self.assertRaises(backends.BackendSelectionError):
+            backends.select_backend(
+                device_id="mps",
+                requested_backend="auto",
+                platform_name="Darwin",
+                mlx_available=False,
+            )
+
+    def test_manual_mlx_requires_mac(self):
+        with self.assertRaises(backends.BackendSelectionError):
+            backends.select_backend(
+                device_id="0", requested_backend="mlx", platform_name="Linux", mlx_available=True
+            )
+
+    def test_manual_mlx_allowed_on_mac(self):
+        choice = backends.select_backend(
+            device_id="mps", requested_backend="mlx", platform_name="Darwin", mlx_available=True
+        )
+        self.assertEqual(choice, "mlx")
+
+
+class RunMlxBackendTests(unittest.TestCase):
+    def setUp(self):
+        self.progress_patch = mock.patch.object(
+            backends, "_progress", new=lambda *args, **kwargs: nullcontext()
+        )
+        self.progress_patch.start()
+
+    def tearDown(self):
+        self.progress_patch.stop()
+
+    def test_whisper_word_timestamps(self):
+        calls = []
+
+        class FakeWhisper:
+            @staticmethod
+            def transcribe(audio_path, *, path_or_hf_repo, word_timestamps, verbose, **decode_options):
+                calls.append(
+                    {
+                        "audio_path": audio_path,
+                        "repo": path_or_hf_repo,
+                        "word_timestamps": word_timestamps,
+                        "decode_options": decode_options,
+                    }
+                )
+                return {
+                    "text": "hello world",
+                    "segments": [
+                        {
+                            "start": 0.0,
+                            "end": 1.0,
+                            "text": "hello world",
+                            "words": [
+                                {"start": 0.0, "end": 0.5, "word": "hello"},
+                                {"start": 0.5, "end": 1.0, "word": "world"},
+                            ],
+                        }
+                    ],
+                }
+
+        with mock.patch.object(backends, "_import_mlx_module", return_value=FakeWhisper()):
+            result = backends.run_mlx_backend(
+                audio_path="sample.wav",
+                model_name="openai/whisper-large-v3",
+                task="transcribe",
+                language="en",
+                timestamp="word",
+                batch_size=24,
+                mlx_model="whisper",
+            )
+
+        self.assertEqual(result["text"], "hello world")
+        self.assertEqual(
+            result["chunks"],
+            [
+                {"timestamp": (0.0, 0.5), "text": "hello"},
+                {"timestamp": (0.5, 1.0), "text": "world"},
+            ],
+        )
+        self.assertEqual(calls[0]["repo"], "mlx-community/whisper-large-v3")
+        self.assertTrue(calls[0]["word_timestamps"])
+        self.assertEqual(calls[0]["decode_options"], {"task": "transcribe", "language": "en"})
+
+    def test_parakeet_requires_model_override(self):
+        with mock.patch.object(backends, "_import_mlx_module", return_value=object()):
+            with self.assertRaises(backends.BackendSelectionError):
+                backends.run_mlx_backend(
+                    audio_path="sample.wav",
+                    model_name="openai/whisper-large-v3",
+                    task="transcribe",
+                    language=None,
+                    timestamp="chunk",
+                    batch_size=24,
+                    mlx_model="parakeet",
+                )
+
+    def test_parakeet_chunk_timestamps(self):
+        calls = []
+
+        class FakeParakeet:
+            @staticmethod
+            def transcribe(audio_path, *, path_or_hf_repo, word_timestamps, verbose, **decode_options):
+                calls.append(
+                    {
+                        "audio_path": audio_path,
+                        "repo": path_or_hf_repo,
+                        "word_timestamps": word_timestamps,
+                        "decode_options": decode_options,
+                    }
+                )
+                return {
+                    "text": "segment text",
+                    "segments": [
+                        {
+                            "start": 1.0,
+                            "end": 2.5,
+                            "text": "segment text",
+                        }
+                    ],
+                }
+
+        with mock.patch.object(backends, "_import_mlx_module", return_value=FakeParakeet()):
+            result = backends.run_mlx_backend(
+                audio_path="sample.wav",
+                model_name="mlx-community/parakeet-large",
+                task="translate",
+                language="fr",
+                timestamp="chunk",
+                batch_size=24,
+                mlx_model="parakeet",
+            )
+
+        self.assertEqual(result["text"], "segment text")
+        self.assertEqual(result["chunks"], [{"timestamp": (1.0, 2.5), "text": "segment text"}])
+        self.assertEqual(calls[0]["repo"], "mlx-community/parakeet-large")
+        self.assertFalse(calls[0]["word_timestamps"])
+        self.assertEqual(calls[0]["decode_options"], {"task": "translate", "language": "fr"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,174 +1,139 @@
+import importlib
 import pathlib
 import sys
-import unittest
-from contextlib import nullcontext
 from unittest import mock
+
+import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from insanely_fast_whisper import backends
 
 
-class AvailabilityTests(unittest.TestCase):
-    def test_is_mlx_available_when_whisper_installed(self):
-        with mock.patch("importlib.util.find_spec", side_effect=lambda name: object() if name == "mlx_whisper" else None):
-            self.assertTrue(backends.is_mlx_available())
-
-    def test_is_mlx_available_when_parakeet_installed(self):
-        with mock.patch("importlib.util.find_spec", side_effect=lambda name: object() if name == "mlx_parakeet" else None):
-            self.assertTrue(backends.is_mlx_available())
-
-    def test_is_mlx_unavailable_when_no_packages_found(self):
-        with mock.patch("importlib.util.find_spec", return_value=None):
-            self.assertFalse(backends.is_mlx_available())
+def test_is_mlx_available_checks_both_packages():
+    specs = {"mlx_whisper": object(), "mlx_parakeet": None}
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: specs.get(name)):  # type: ignore[arg-type]
+        assert backends.is_mlx_available()
 
 
-class SelectBackendTests(unittest.TestCase):
-    def test_auto_prefers_transformers_on_cuda(self):
-        choice = backends.select_backend(
-            device_id="0", requested_backend="auto", platform_name="Linux", mlx_available=False
+@pytest.mark.parametrize(
+    "device_id,platform_name,mlx_available,expected",
+    [
+        ("0", "Linux", False, "transformers"),
+        ("mps", "Darwin", True, "mlx"),
+    ],
+)
+def test_select_backend_auto(device_id, platform_name, mlx_available, expected):
+    assert (
+        backends.select_backend(
+            device_id=device_id,
+            requested_backend="auto",
+            platform_name=platform_name,
+            mlx_available=mlx_available,
         )
-        self.assertEqual(choice, "transformers")
+        == expected
+    )
 
-    def test_auto_requires_mlx_packages_on_mac(self):
-        with self.assertRaises(backends.BackendSelectionError):
-            backends.select_backend(
-                device_id="mps",
-                requested_backend="auto",
-                platform_name="Darwin",
-                mlx_available=False,
-            )
 
-    def test_manual_mlx_requires_mac(self):
-        with self.assertRaises(backends.BackendSelectionError):
-            backends.select_backend(
-                device_id="0", requested_backend="mlx", platform_name="Linux", mlx_available=True
-            )
-
-    def test_manual_mlx_allowed_on_mac(self):
-        choice = backends.select_backend(
-            device_id="mps", requested_backend="mlx", platform_name="Darwin", mlx_available=True
+def test_select_backend_auto_requires_mlx_on_mac():
+    with pytest.raises(backends.BackendSelectionError):
+        backends.select_backend(
+            device_id="mps",
+            requested_backend="auto",
+            platform_name="Darwin",
+            mlx_available=False,
         )
-        self.assertEqual(choice, "mlx")
 
 
-class RunMlxBackendTests(unittest.TestCase):
-    def setUp(self):
-        self.progress_patch = mock.patch.object(
-            backends, "_progress", new=lambda *args, **kwargs: nullcontext()
+def test_manual_mlx_requires_mac():
+    with pytest.raises(backends.BackendSelectionError):
+        backends.select_backend(
+            device_id="0",
+            requested_backend="mlx",
+            platform_name="Linux",
+            mlx_available=True,
         )
-        self.progress_patch.start()
 
-    def tearDown(self):
-        self.progress_patch.stop()
 
-    def test_whisper_word_timestamps(self):
-        calls = []
-
-        class FakeWhisper:
-            @staticmethod
-            def transcribe(audio_path, *, path_or_hf_repo, word_timestamps, verbose, **decode_options):
-                calls.append(
+def test_run_mlx_backend_word_timestamps():
+    class FakeWhisper:
+        @staticmethod
+        def transcribe(audio_path, *, path_or_hf_repo, word_timestamps, verbose, **decode_options):
+            assert audio_path == "sample.wav"
+            assert path_or_hf_repo == "mlx-community/whisper-large-v3"
+            assert word_timestamps is True
+            assert decode_options == {"task": "transcribe", "language": "en"}
+            return {
+                "text": "hello world",
+                "segments": [
                     {
-                        "audio_path": audio_path,
-                        "repo": path_or_hf_repo,
-                        "word_timestamps": word_timestamps,
-                        "decode_options": decode_options,
+                        "start": 0.0,
+                        "end": 1.0,
+                        "text": "hello world",
+                        "words": [
+                            {"start": 0.0, "end": 0.5, "word": "hello"},
+                            {"start": 0.5, "end": 1.0, "word": "world"},
+                        ],
                     }
-                )
-                return {
-                    "text": "hello world",
-                    "segments": [
-                        {
-                            "start": 0.0,
-                            "end": 1.0,
-                            "text": "hello world",
-                            "words": [
-                                {"start": 0.0, "end": 0.5, "word": "hello"},
-                                {"start": 0.5, "end": 1.0, "word": "world"},
-                            ],
-                        }
-                    ],
-                }
+                ],
+            }
 
-        with mock.patch.object(backends, "_import_mlx_module", return_value=FakeWhisper()):
-            result = backends.run_mlx_backend(
+    with mock.patch.object(importlib, "import_module", return_value=FakeWhisper()):
+        result = backends.run_mlx_backend(
+            audio_path="sample.wav",
+            model_name="openai/whisper-large-v3",
+            task="transcribe",
+            language="en",
+            timestamp="word",
+            mlx_model="whisper",
+        )
+
+    assert result["text"] == "hello world"
+    assert result["chunks"] == [
+        {"timestamp": (0.0, 0.5), "text": "hello"},
+        {"timestamp": (0.5, 1.0), "text": "world"},
+    ]
+
+
+def test_run_mlx_backend_parakeet_requires_model_override():
+    with mock.patch.object(importlib, "import_module", return_value=object()):
+        with pytest.raises(backends.BackendSelectionError):
+            backends.run_mlx_backend(
                 audio_path="sample.wav",
                 model_name="openai/whisper-large-v3",
                 task="transcribe",
-                language="en",
-                timestamp="word",
-                batch_size=24,
-                mlx_model="whisper",
-            )
-
-        self.assertEqual(result["text"], "hello world")
-        self.assertEqual(
-            result["chunks"],
-            [
-                {"timestamp": (0.0, 0.5), "text": "hello"},
-                {"timestamp": (0.5, 1.0), "text": "world"},
-            ],
-        )
-        self.assertEqual(calls[0]["repo"], "mlx-community/whisper-large-v3")
-        self.assertTrue(calls[0]["word_timestamps"])
-        self.assertEqual(calls[0]["decode_options"], {"task": "transcribe", "language": "en"})
-
-    def test_parakeet_requires_model_override(self):
-        with mock.patch.object(backends, "_import_mlx_module", return_value=object()):
-            with self.assertRaises(backends.BackendSelectionError):
-                backends.run_mlx_backend(
-                    audio_path="sample.wav",
-                    model_name="openai/whisper-large-v3",
-                    task="transcribe",
-                    language=None,
-                    timestamp="chunk",
-                    batch_size=24,
-                    mlx_model="parakeet",
-                )
-
-    def test_parakeet_chunk_timestamps(self):
-        calls = []
-
-        class FakeParakeet:
-            @staticmethod
-            def transcribe(audio_path, *, path_or_hf_repo, word_timestamps, verbose, **decode_options):
-                calls.append(
-                    {
-                        "audio_path": audio_path,
-                        "repo": path_or_hf_repo,
-                        "word_timestamps": word_timestamps,
-                        "decode_options": decode_options,
-                    }
-                )
-                return {
-                    "text": "segment text",
-                    "segments": [
-                        {
-                            "start": 1.0,
-                            "end": 2.5,
-                            "text": "segment text",
-                        }
-                    ],
-                }
-
-        with mock.patch.object(backends, "_import_mlx_module", return_value=FakeParakeet()):
-            result = backends.run_mlx_backend(
-                audio_path="sample.wav",
-                model_name="mlx-community/parakeet-large",
-                task="translate",
-                language="fr",
+                language=None,
                 timestamp="chunk",
-                batch_size=24,
                 mlx_model="parakeet",
             )
 
-        self.assertEqual(result["text"], "segment text")
-        self.assertEqual(result["chunks"], [{"timestamp": (1.0, 2.5), "text": "segment text"}])
-        self.assertEqual(calls[0]["repo"], "mlx-community/parakeet-large")
-        self.assertFalse(calls[0]["word_timestamps"])
-        self.assertEqual(calls[0]["decode_options"], {"task": "translate", "language": "fr"})
 
+def test_run_mlx_backend_parakeet_uses_chunks():
+    class FakeParakeet:
+        @staticmethod
+        def transcribe(audio_path, *, path_or_hf_repo, word_timestamps, verbose, **decode_options):
+            assert path_or_hf_repo == "mlx-community/parakeet-large"
+            assert word_timestamps is False
+            assert decode_options == {"task": "translate", "language": "fr"}
+            return {
+                "text": "segment text",
+                "segments": [
+                    {
+                        "start": 1.0,
+                        "end": 2.5,
+                        "text": "segment text",
+                    }
+                ],
+            }
 
-if __name__ == "__main__":
-    unittest.main()
+    with mock.patch.object(importlib, "import_module", return_value=FakeParakeet()):
+        result = backends.run_mlx_backend(
+            audio_path="sample.wav",
+            model_name="mlx-community/parakeet-large",
+            task="translate",
+            language="fr",
+            timestamp="chunk",
+            mlx_model="parakeet",
+        )
+
+    assert result["chunks"] == [{"timestamp": (1.0, 2.5), "text": "segment text"}]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -11,7 +11,7 @@ from insanely_fast_whisper import backends
 
 
 def test_is_mlx_available_checks_both_packages():
-    specs = {"mlx_whisper": object(), "mlx_parakeet": None}
+    specs = {"mlx_whisper": object(), "parakeet_mlx": None}
     with mock.patch("importlib.util.find_spec", side_effect=lambda name: specs.get(name)):  # type: ignore[arg-type]
         assert backends.is_mlx_available()
 


### PR DESCRIPTION
## Summary
- ensure the mac optional extra installs the MLX Parakeet backend alongside MLX Whisper
- treat the MLX backend as available when either Whisper or Parakeet runtimes are installed and document the extra
- add regression tests covering MLX availability checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fc805c0a188328a0b3169dd0c02336