### PR TITLE
diarize.py: handle empty pyannote segments without IndexError

### DIFF
--- a/src/insanely_fast_whisper/utils/diarize.py
+++ b/src/insanely_fast_whisper/utils/diarize.py
@@ -76,6 +76,12 @@ def diarize_audio(diarizer_inputs, diarization_pipeline, num_speakers, min_speak
             }
         )
 
+    # No speakers detected (e.g. audio is silent, music-only, or otherwise
+    # contains no recognizable speech). Return an empty list rather than
+    # IndexError-ing on segments[0] below.
+    if not segments:
+        return []
+
     # diarizer output may contain consecutive segments from the same speaker (e.g. {(0 -> 1, speaker_1), (1 -> 1.5, speaker_1), ...})
     # we combine these segments to give overall timestamps for each speaker's turn (e.g. {(0 -> 1.5, speaker_1), ...})
     new_segments = []


### PR DESCRIPTION
When the diarization pipeline (`pyannote.audio`) returns zero speaker segments — e.g. audio that is silent, contains music only, or has no recognizable speech — `diarize_audio` crashes with:

```
File "src/insanely_fast_whisper/utils/diarize.py", line 82, in diarize_audio
    prev_segment = cur_segment = segments[0]
IndexError: list index out of range
```

This is correct pyannote behavior (no speech → no segments), but it cascades into an unhelpful traceback for the caller. We should treat "zero segments" the same way we'd treat any "no speakers detected" case: return an empty list and let the caller proceed.

I hit this in production transcribing music samples through the `--hf-token` path. Debugged ~40 minutes before realizing the issue was upstream of any auth/scope/network failure.

### Repro

```bash
# Any audio with no speech (e.g. a piano recording)
insanely-fast-whisper \
    --file-name piano.wav \
    --device-id 0 \
    --model-name openai/whisper-large-v3 \
    --task transcribe \
    --transcript-path out.json \
    --hf-token <valid-token-with-pyannote-access> \
    --batch-size 8
```

Result: transcription succeeds (Whisper produces empty/hallucinated text), but `diarize_audio` crashes on `segments[0]` before the result is written.

### Diff

```diff
+    # No speakers detected (e.g. audio is silent, music-only, or otherwise
+    # contains no recognizable speech). Return an empty list rather than
+    # IndexError-ing on segments[0] below.
+    if not segments:
+        return []
+
     # diarizer output may contain consecutive segments...
     new_segments = []
     prev_segment = cur_segment = segments[0]
```

If you'd prefer richer behavior — e.g., emit `[{"speaker": "UNKNOWN", "text": "(no speech detected)"}]` — happy to expand. The minimal return-empty is the smallest change that prevents the crash without altering the existing happy-path output shape.