### PR TITLE
fix: survive torchcodec installs that cannot be loaded

### DIFF
--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -7,6 +7,26 @@ import torch
 from .utils.diarization_pipeline import diarize
 from .utils.result import build_result
 
+
+def disable_torchcodec_if_broken():
+    """Hide an unusable torchcodec install from the transformers ASR pipeline.
+
+    transformers imports torchcodec whenever the package is present, even for
+    inputs that never need it. torchcodec wheels are binary-tied to a specific
+    torch release but declare no torch requirement in their metadata, so
+    resolvers routinely install mismatched pairs whose import crashes with an
+    OSError -- taking every transcription down with it.
+    """
+    try:
+        import torchcodec  # noqa: F401
+        return False
+    except Exception:
+        from transformers.pipelines import automatic_speech_recognition
+
+        if hasattr(automatic_speech_recognition, "is_torchcodec_available"):
+            automatic_speech_recognition.is_torchcodec_available = lambda: False
+        return True
+
 parser = argparse.ArgumentParser(description="Automatic Speech Recognition")
 parser.add_argument(
     "--file-name",
@@ -110,6 +130,13 @@ parser.add_argument(
 
 def main():
     args = parser.parse_args()
+
+    if disable_torchcodec_if_broken():
+        print(
+            "⚠️ The installed torchcodec package cannot be loaded (it was likely "
+            "built for a different torch or FFmpeg version). Ignoring it and "
+            "decoding audio with ffmpeg instead."
+        )
 
     if args.num_speakers is not None and (args.min_speakers is not None or args.max_speakers is not None):
         parser.error("--num-speakers cannot be used together with --min-speakers or --max-speakers.")

--- a/tests/test_torchcodec_guard.py
+++ b/tests/test_torchcodec_guard.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+import pytest
+
+from insanely_fast_whisper.cli import disable_torchcodec_if_broken
+
+
+class RaisingFinder:
+    """Import hook that makes `import torchcodec` fail like a bad wheel does."""
+
+    def find_spec(self, name, path=None, target=None):
+        if name == "torchcodec":
+            raise OSError("Could not load this library: libtorchcodec_core8.dylib")
+        return None
+
+
+@pytest.fixture
+def no_torchcodec(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torchcodec", raising=False)
+    finder = RaisingFinder()
+    sys.meta_path.insert(0, finder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+
+
+def test_broken_torchcodec_is_disabled(no_torchcodec):
+    from transformers.pipelines import automatic_speech_recognition
+
+    assert disable_torchcodec_if_broken() is True
+    assert automatic_speech_recognition.is_torchcodec_available() is False
+
+
+def test_healthy_torchcodec_is_left_alone(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torchcodec", types.ModuleType("torchcodec"))
+    assert disable_torchcodec_if_broken() is False


### PR DESCRIPTION
A fresh `pip install insanely-fast-whisper` is currently broken: every transcription crashes with `OSError: Could not load this library: ...libtorchcodec_core8.dylib` (or a similar dlopen failure) before any audio is processed.

**Why this happens**

- The unpinned dependencies now resolve to transformers 5.12.1 + torch 2.10.0 + pyannote-audio 4.0.7, and pyannote-audio 4.x depends on `torchcodec`.
- torchcodec wheels are binary-tied to one torch release, but declare **no torch requirement in their package metadata** (`importlib.metadata.requires("torchcodec")` has no torch entry), so resolvers happily install mismatched pairs (here: torchcodec 0.14 with torch 2.10).
- transformers' ASR pipeline does `import torchcodec` whenever the package is *installed* — even for plain file-path inputs it decodes with ffmpeg anyway — so the broken import takes down every run.

**The fix**

Probe `import torchcodec` once at startup; if it fails, patch the pipeline's `is_torchcodec_available` to return False and print a warning. Decoding falls back to ffmpeg exactly as before. No behavior change on healthy installs.

**Verification** (Apple Silicon, macOS 15.6, Python 3.11, fresh dependency resolution as above)

- `main`: crashes with the OSError on 100% of runs.
- This branch: `--model-name openai/whisper-tiny --device-id mps` transcribes a 60 s WAV in ~22 s including model load; `--timestamp word` also works (186 word chunks).
- 2 unit tests simulate the broken and healthy import paths.

Related: this is also why the transformers-backend test in #273 skips (`pytest.skip` on torchcodec errors) — with this guard in place it can run instead. I'll file the unconditional-import issue upstream with transformers and link it here.
