### PR TITLE
fix: parse --flash as a proper boolean flag

### DIFF
--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -7,6 +7,20 @@ import torch
 from .utils.diarization_pipeline import diarize
 from .utils.result import build_result
 
+
+def str2bool(value):
+    if isinstance(value, bool):
+        return value
+    normalized = value.strip().lower()
+    if normalized in ("true", "1", "yes", "y"):
+        return True
+    if normalized in ("false", "0", "no", "n"):
+        return False
+    raise argparse.ArgumentTypeError(
+        f"Expected a boolean value (true/false), got {value!r}."
+    )
+
+
 parser = argparse.ArgumentParser(description="Automatic Speech Recognition")
 parser.add_argument(
     "--file-name",
@@ -60,7 +74,9 @@ parser.add_argument(
 parser.add_argument(
     "--flash",
     required=False,
-    type=bool,
+    type=str2bool,
+    nargs="?",
+    const=True,
     default=False,
     help="Use Flash Attention 2. Read the FAQs to see how to install FA2 correctly. (default: False)",
 )

--- a/tests/test_flash_flag.py
+++ b/tests/test_flash_flag.py
@@ -1,0 +1,39 @@
+import argparse
+
+import pytest
+
+from insanely_fast_whisper.cli import parser, str2bool
+
+BASE_ARGS = ["--file-name", "audio.wav"]
+
+
+def parse_flash(extra):
+    return parser.parse_args(BASE_ARGS + extra).flash
+
+
+def test_flash_defaults_to_false():
+    assert parse_flash([]) is False
+
+
+def test_flash_bare_flag_enables():
+    assert parse_flash(["--flash"]) is True
+
+
+@pytest.mark.parametrize("value", ["True", "true", "1", "yes", "Y"])
+def test_flash_truthy_values(value):
+    assert parse_flash(["--flash", value]) is True
+
+
+@pytest.mark.parametrize("value", ["False", "false", "0", "no", "N"])
+def test_flash_falsy_values(value):
+    assert parse_flash(["--flash", value]) is False
+
+
+def test_flash_rejects_garbage():
+    with pytest.raises(SystemExit):
+        parser.parse_args(BASE_ARGS + ["--flash", "maybe"])
+
+
+def test_str2bool_rejects_garbage_directly():
+    with pytest.raises(argparse.ArgumentTypeError):
+        str2bool("maybe")


### PR DESCRIPTION
`--flash` is declared with `type=bool`, and `bool("False")` is `True` in Python — so `--flash False` (and `--flash anything`) silently **enables** Flash Attention 2. Anyone who tried to turn flash off this way has been running FA2 unknowingly, which is likely behind a chunk of the confusing FA2 reports (e.g. the "model not initialized on GPU" reports in #210/#253 from users who thought flash was off).

Changes:

- `--flash True` / `--flash False` (and `1/0`, `yes/no`, case-insensitive) now mean what they say — the README's documented `--flash True` keeps working unchanged.
- Bare `--flash` works as shorthand for enabling it.
- Garbage values (`--flash maybe`) exit with a clear error instead of silently becoming `True`.

14 parser tests included.
