### PR TITLE
fix: handle empty diarization output and empty transcripts

### DIFF
--- a/src/insanely_fast_whisper/utils/diarize.py
+++ b/src/insanely_fast_whisper/utils/diarize.py
@@ -76,6 +76,10 @@ def diarize_audio(diarizer_inputs, diarization_pipeline, num_speakers, min_speak
             }
         )
 
+    # the diarizer may find no speech at all (e.g. silence or music-only audio)
+    if not segments:
+        return []
+
     # diarizer output may contain consecutive segments from the same speaker (e.g. {(0 -> 1, speaker_1), (1 -> 1.5, speaker_1), ...})
     # we combine these segments to give overall timestamps for each speaker's turn (e.g. {(0 -> 1.5, speaker_1), ...})
     new_segments = []
@@ -120,6 +124,9 @@ def post_process_segments_and_transcripts(new_segments, transcript, group_by_spe
 
     # align the diarizer timestamps and the ASR timestamps
     for segment in new_segments:
+        # stop once every transcript chunk has been assigned a speaker
+        if len(end_timestamps) == 0:
+            break
         # get the diarizer end timestamp
         end_time = segment["segment"]["end"]
         # find the ASR end timestamp that is closest to the diarizer's end timestamp and cut the transcript to here
@@ -145,8 +152,5 @@ def post_process_segments_and_transcripts(new_segments, transcript, group_by_spe
         # crop the transcripts and timestamp lists according to the latest timestamp (for faster argmin)
         transcript = transcript[upto_idx + 1:]
         end_timestamps = end_timestamps[upto_idx + 1:]
-
-        if len(end_timestamps) == 0:
-            break 
 
     return segmented_preds

--- a/tests/test_diarize_postprocess.py
+++ b/tests/test_diarize_postprocess.py
@@ -1,0 +1,80 @@
+from insanely_fast_whisper.utils.diarize import (
+    diarize_audio,
+    post_process_segments_and_transcripts,
+)
+
+
+class FakeSegment:
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+
+class FakeAnnotation:
+    def __init__(self, tracks):
+        self._tracks = tracks
+
+    def itertracks(self, yield_label=False):
+        yield from self._tracks
+
+
+class FakePipeline:
+    def __init__(self, tracks):
+        self._tracks = tracks
+
+    def __call__(self, inputs, num_speakers=None, min_speakers=None, max_speakers=None):
+        return FakeAnnotation(self._tracks)
+
+
+def test_diarize_audio_empty_diarization_returns_empty():
+    pipeline = FakePipeline([])
+    assert diarize_audio(None, pipeline, None, None, None) == []
+
+
+def test_diarize_audio_merges_consecutive_same_speaker_segments():
+    pipeline = FakePipeline(
+        [
+            (FakeSegment(0.0, 1.0), "t0", "SPEAKER_00"),
+            (FakeSegment(1.0, 2.0), "t1", "SPEAKER_00"),
+            (FakeSegment(2.0, 3.0), "t2", "SPEAKER_01"),
+        ]
+    )
+    assert diarize_audio(None, pipeline, None, None, None) == [
+        {"segment": {"start": 0.0, "end": 2.0}, "speaker": "SPEAKER_00"},
+        {"segment": {"start": 2.0, "end": 3.0}, "speaker": "SPEAKER_01"},
+    ]
+
+
+def test_post_process_empty_transcript_returns_empty():
+    segments = [{"segment": {"start": 0.0, "end": 1.0}, "speaker": "SPEAKER_00"}]
+    assert post_process_segments_and_transcripts(segments, [], group_by_speaker=False) == []
+
+
+def test_post_process_empty_segments_returns_empty():
+    transcript = [{"text": " hi", "timestamp": (0.0, 1.0)}]
+    assert post_process_segments_and_transcripts([], transcript, group_by_speaker=False) == []
+
+
+def test_post_process_assigns_speakers_to_chunks():
+    segments = [
+        {"segment": {"start": 0.0, "end": 2.0}, "speaker": "SPEAKER_00"},
+        {"segment": {"start": 2.0, "end": 4.0}, "speaker": "SPEAKER_01"},
+    ]
+    transcript = [
+        {"text": " hello", "timestamp": (0.0, 2.0)},
+        {"text": " world", "timestamp": (2.0, 4.0)},
+    ]
+    assert post_process_segments_and_transcripts(
+        segments, transcript, group_by_speaker=False
+    ) == [
+        {"speaker": "SPEAKER_00", "text": " hello", "timestamp": (0.0, 2.0)},
+        {"speaker": "SPEAKER_01", "text": " world", "timestamp": (2.0, 4.0)},
+    ]
+
+
+def test_post_process_handles_none_end_timestamp():
+    segments = [{"segment": {"start": 0.0, "end": 2.0}, "speaker": "SPEAKER_00"}]
+    transcript = [{"text": " hello", "timestamp": (0.0, None)}]
+    assert post_process_segments_and_transcripts(
+        segments, transcript, group_by_speaker=False
+    ) == [{"speaker": "SPEAKER_00", "text": " hello", "timestamp": (0.0, None)}]


### PR DESCRIPTION
Two crashes in the diarization post-processing, both hit in the wild:

1. `diarize_audio` indexes `segments[0]` and raises `IndexError` when pyannote finds no speech at all (silence / music-only audio) — reported in #278 and #277.
2. `post_process_segments_and_transcripts` calls `np.argmin` on an empty array and raises `ValueError: attempt to get argmin of an empty sequence` when no transcript chunks remain to align (second error in #199).

Both cases now return an empty speaker list so the transcription output is still written.

This consolidates and supersedes #277 (@JasonOA888) and #278 (@victorkjung) — same `IndexError` fix, plus the `argmin` case, plus regression tests for the segment-merge and speaker-alignment logic (6 tests; the two crash tests fail on `main`).
