### PR TITLE
Add OpenAI-compatible ASR backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ insanely-fast-whisper --file-name <filename or URL> --flash True
 insanely-fast-whisper --model-name distil-whisper/large-v2 --file-name <filename or URL> 
 ```
 
+You can also point the CLI at a local OpenAI-compatible transcription server,
+such as FunASR/SenseVoice:
+
+```bash
+funasr-server --model iic/SenseVoiceSmall --host 127.0.0.1 --port 8000
+
+insanely-fast-whisper \
+  --backend openai-compatible \
+  --openai-compatible-url http://127.0.0.1:8000/v1/audio/transcriptions \
+  --model-name iic/SenseVoiceSmall \
+  --file-name meeting.wav
+```
+
 Don't want to install `insanely-fast-whisper`? Just use `pipx run`:
 
 ```bash
@@ -89,6 +102,12 @@ The `insanely-fast-whisper` repo provides an all round support for running Whisp
                         Path to save the transcription output. (default: output.json)
   --model-name MODEL_NAME
                         Name of the pretrained model/ checkpoint to perform ASR. (default: openai/whisper-large-v3)
+  --backend {transformers,openai-compatible}
+                        ASR backend to use. Use openai-compatible for local servers such as FunASR/SenseVoice. (default: transformers)
+  --openai-compatible-url OPENAI_COMPATIBLE_URL
+                        OpenAI-compatible transcription endpoint used when --backend openai-compatible.
+  --openai-compatible-api-key OPENAI_COMPATIBLE_API_KEY
+                        Optional bearer token for --backend openai-compatible.
   --task {transcribe,translate}
                         Task to perform: transcribe or translate to another language. (default: transcribe)
   --language LANGUAGE   

--- a/src/insanely_fast_whisper/cli.py
+++ b/src/insanely_fast_whisper/cli.py
@@ -1,10 +1,12 @@
 import json
 import argparse
-from transformers import pipeline
+import mimetypes
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib import request
 from rich.progress import Progress, TimeElapsedColumn, BarColumn, TextColumn
-import torch
 
-from .utils.diarization_pipeline import diarize
 from .utils.result import build_result
 
 parser = argparse.ArgumentParser(description="Automatic Speech Recognition")
@@ -34,6 +36,28 @@ parser.add_argument(
     default="openai/whisper-large-v3",
     type=str,
     help="Name of the pretrained model/ checkpoint to perform ASR. (default: openai/whisper-large-v3)",
+)
+parser.add_argument(
+    "--backend",
+    required=False,
+    default="transformers",
+    type=str,
+    choices=["transformers", "openai-compatible"],
+    help="ASR backend to use. Use openai-compatible for local servers such as FunASR/SenseVoice. (default: transformers)",
+)
+parser.add_argument(
+    "--openai-compatible-url",
+    required=False,
+    default="http://127.0.0.1:8000/v1/audio/transcriptions",
+    type=str,
+    help="OpenAI-compatible transcription endpoint used when --backend openai-compatible.",
+)
+parser.add_argument(
+    "--openai-compatible-api-key",
+    required=False,
+    default=None,
+    type=str,
+    help="Optional bearer token for --backend openai-compatible.",
 )
 parser.add_argument(
     "--task",
@@ -108,24 +132,78 @@ parser.add_argument(
     help="Defines the maximum number of speakers that the system should consider in diarization. Must be at least 1. Cannot be used together with --num-speakers. Must be greater than or equal to --min-speakers if both are specified. (default: None)",
 )
 
-def main():
-    args = parser.parse_args()
+def _normalize_transcription_response(response: dict[str, Any]) -> dict[str, Any]:
+    chunks = []
+    for segment in response.get("segments") or []:
+        if not isinstance(segment, dict):
+            continue
+        chunks.append(
+            {
+                "text": segment.get("text", ""),
+                "timestamp": [segment.get("start"), segment.get("end")],
+            }
+        )
 
-    if args.num_speakers is not None and (args.min_speakers is not None or args.max_speakers is not None):
-        parser.error("--num-speakers cannot be used together with --min-speakers or --max-speakers.")
+    return {"text": response.get("text", ""), "chunks": chunks}
 
-    if args.num_speakers is not None and args.num_speakers < 1:
-        parser.error("--num-speakers must be at least 1.")
 
-    if args.min_speakers is not None and args.min_speakers < 1:
-        parser.error("--min-speakers must be at least 1.")
+def _build_multipart_body(fields: dict[str, str], file_path: str) -> tuple[bytes, str]:
+    path = Path(file_path)
+    if not path.is_file():
+        raise ValueError("--backend openai-compatible requires --file-name to be a local file path")
 
-    if args.max_speakers is not None and args.max_speakers < 1:
-        parser.error("--max-speakers must be at least 1.")
+    boundary = f"----insanely-fast-whisper-{uuid.uuid4().hex}"
+    body = bytearray()
 
-    if args.min_speakers is not None and args.max_speakers is not None and args.min_speakers > args.max_speakers:
-        if args.min_speakers > args.max_speakers:
-            parser.error("--min-speakers cannot be greater than --max-speakers.")
+    for name, value in fields.items():
+        body.extend(f"--{boundary}\r\n".encode())
+        body.extend(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode())
+        body.extend(str(value).encode())
+        body.extend(b"\r\n")
+
+    content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    body.extend(f"--{boundary}\r\n".encode())
+    body.extend(
+        (
+            f'Content-Disposition: form-data; name="file"; filename="{path.name}"\r\n'
+            f"Content-Type: {content_type}\r\n\r\n"
+        ).encode()
+    )
+    body.extend(path.read_bytes())
+    body.extend(b"\r\n")
+    body.extend(f"--{boundary}--\r\n".encode())
+    return bytes(body), f"multipart/form-data; boundary={boundary}"
+
+
+def transcribe_openai_compatible(args) -> dict[str, Any]:
+    language = None if args.language == "None" else args.language
+    fields = {
+        "model": args.model_name,
+        "response_format": "verbose_json",
+    }
+    if language:
+        fields["language"] = language
+
+    body, content_type = _build_multipart_body(fields, args.file_name)
+    headers = {"Content-Type": content_type}
+    if args.openai_compatible_api_key:
+        headers["Authorization"] = f"Bearer {args.openai_compatible_api_key}"
+
+    transcription_request = request.Request(
+        args.openai_compatible_url,
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    with request.urlopen(transcription_request) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    return _normalize_transcription_response(payload)
+
+
+def transcribe_transformers(args) -> dict[str, Any]:
+    import torch
+    from transformers import pipeline
 
     pipe = pipeline(
         "automatic-speech-recognition",
@@ -149,6 +227,34 @@ def main():
     if args.model_name.split(".")[-1] == "en":
         generate_kwargs.pop("task")
 
+    return pipe(
+        args.file_name,
+        chunk_length_s=30,
+        batch_size=args.batch_size,
+        generate_kwargs=generate_kwargs,
+        return_timestamps=ts,
+    )
+
+
+def main():
+    args = parser.parse_args()
+
+    if args.num_speakers is not None and (args.min_speakers is not None or args.max_speakers is not None):
+        parser.error("--num-speakers cannot be used together with --min-speakers or --max-speakers.")
+
+    if args.num_speakers is not None and args.num_speakers < 1:
+        parser.error("--num-speakers must be at least 1.")
+
+    if args.min_speakers is not None and args.min_speakers < 1:
+        parser.error("--min-speakers must be at least 1.")
+
+    if args.max_speakers is not None and args.max_speakers < 1:
+        parser.error("--max-speakers must be at least 1.")
+
+    if args.min_speakers is not None and args.max_speakers is not None and args.min_speakers > args.max_speakers:
+        if args.min_speakers > args.max_speakers:
+            parser.error("--min-speakers cannot be greater than --max-speakers.")
+
     with Progress(
         TextColumn("🤗 [progress.description]{task.description}"),
         BarColumn(style="yellow1", pulse_style="white"),
@@ -156,15 +262,14 @@ def main():
     ) as progress:
         progress.add_task("[yellow]Transcribing...", total=None)
 
-        outputs = pipe(
-            args.file_name,
-            chunk_length_s=30,
-            batch_size=args.batch_size,
-            generate_kwargs=generate_kwargs,
-            return_timestamps=ts,
-        )
+        if args.backend == "openai-compatible":
+            outputs = transcribe_openai_compatible(args)
+        else:
+            outputs = transcribe_transformers(args)
 
     if args.hf_token != "no_token":
+        from .utils.diarization_pipeline import diarize
+
         speakers_transcript = diarize(args, outputs)
         with open(args.transcript_path, "w", encoding="utf8") as fp:
             result = build_result(speakers_transcript, outputs)

--- a/tests/test_openai_compatible_backend.py
+++ b/tests/test_openai_compatible_backend.py
@@ -1,0 +1,78 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from insanely_fast_whisper.cli import (
+    _build_multipart_body,
+    _normalize_transcription_response,
+    transcribe_openai_compatible,
+)
+
+
+def test_normalize_verbose_json_segments():
+    result = _normalize_transcription_response(
+        {
+            "text": "hello world",
+            "segments": [
+                {"start": 0.0, "end": 0.8, "text": "hello"},
+                {"start": 0.8, "end": 1.4, "text": " world"},
+            ],
+        }
+    )
+
+    assert result == {
+        "text": "hello world",
+        "chunks": [
+            {"text": "hello", "timestamp": [0.0, 0.8]},
+            {"text": " world", "timestamp": [0.8, 1.4]},
+        ],
+    }
+
+
+def test_build_multipart_body_rejects_urls():
+    with pytest.raises(ValueError, match="local file path"):
+        _build_multipart_body({"model": "iic/SenseVoiceSmall"}, "https://example.com/audio.wav")
+
+
+def test_transcribe_openai_compatible_posts_audio(tmp_path):
+    audio = tmp_path / "sample.wav"
+    audio.write_bytes(b"RIFF....WAVE")
+    args = SimpleNamespace(
+        file_name=str(audio),
+        model_name="iic/SenseVoiceSmall",
+        language="zh",
+        openai_compatible_url="http://127.0.0.1:8000/v1/audio/transcriptions",
+        openai_compatible_api_key="token",
+    )
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "text": "你好",
+                    "segments": [{"start": 0, "end": 1, "text": "你好"}],
+                }
+            ).encode("utf-8")
+
+    with patch("insanely_fast_whisper.cli.request.urlopen", return_value=FakeResponse()) as urlopen:
+        result = transcribe_openai_compatible(args)
+
+    sent_request = urlopen.call_args.args[0]
+    body = sent_request.data
+
+    assert sent_request.full_url == "http://127.0.0.1:8000/v1/audio/transcriptions"
+    assert sent_request.headers["Authorization"] == "Bearer token"
+    assert b'name="model"' in body
+    assert b"iic/SenseVoiceSmall" in body
+    assert b'name="language"' in body
+    assert b"zh" in body
+    assert b'name="file"; filename="sample.wav"' in body
+    assert result == {"text": "你好", "chunks": [{"text": "你好", "timestamp": [0, 1]}]}


### PR DESCRIPTION
## Current Readiness

This proposal is not ready to merge. Fresh checks at unchanged head `c331d0b845c4e49b0f4fe309e366b4313a818e4b` found three correctness gaps that the existing tests do not cover:

1. **Python 3.8 CLI import fails.** The project declares `requires-python = ">=3.8"`, but the newly added eager `dict[str, Any]` annotation in `cli.py:135` raises `TypeError: 'type' object is not subscriptable` on CPython 3.8.20, before backend selection.
2. **The HTTP backend silently ignores `--task translate`.** An actual CLI invocation still POSTs to `/v1/audio/transcriptions` with the same form fields as ordinary transcription and writes a successful transcript result. It neither selects a translation operation nor rejects the unsupported request.
3. **The HTTP backend silently ignores `--timestamp word`.** It sends no word-granularity field and normalizes only `segments`, discarding a server-provided `words` array. A fixture response containing one segment and two timed words produces one chunk even in word mode.

These gaps are recorded, not fixed by this update. The intended repair scope is Python 3.8 annotation compatibility, correct word-timestamp request/result handling, and explicit rejection of unsupported HTTP translation requests, with regressions for each. No translation endpoint or new inference engine is proposed here.

## Summary

- Add opt-in `--backend openai-compatible` for a separately running transcription server such as FunASR/SenseVoice.
- Upload a **local file** as multipart data, with optional bearer authentication, to the configured endpoint. This sends the audio to that endpoint; it is local processing only when the server is local.
- Normalize verbose JSON `segments` into the existing `{text, chunks}` output and retain the existing JSON writer.
- Defer Transformers, Torch, and Pyannote imports until their paths are needed. This changes import timing, not the package's declared heavy installation dependencies.
- Include a README example for a preconfigured FunASR server. The server and its matching runtime/model dependencies must be installed separately.

The proposed HTTP backend does not bundle SenseVoice, provide translation, guarantee word timestamps on the current head, or establish diarization compatibility through the checks below.

Closes #279.

## Fresh Validation (2026-09-22)

- On Python 3.11.15, the existing `tests/test_openai_compatible_backend.py` suite still reports **3 passed**.
- A loopback HTTP fixture exercised the actual `cli.main()` parser, multipart upload, response normalization, and JSON writer for default, `--task translate`, and `--timestamp word` invocations. All three currently produce the same request fields and segment-level output, reproducing the latter two gaps above. Multipart fields were parsed using the standard-library MIME parser, not substring guesses.
- The fixture supplied controlled JSON, not model inference. No Torch, Transformers, or Pyannote module was loaded during these non-diarized CLI invocations.
- A real CPython 3.8.20 interpreter reproduced the import error above. `rich>=13.7.0` resolved to a compatible release without ignoring Python requirements or bypassing version checks.
- These were focused source-tree environments with `pytest` and `rich`, **not full package-install acceptance**. No real FunASR HTTP service, GPU/MPS inference, default Whisper path, or diarization run was validated this round.
- At inspection, GitHub returned no check runs or commit statuses for this head. That is not evidence of passing hosted CI.

No source edits, new commit, or push were made in this follow-up. The earlier three-test result remains valid only for its narrow coverage and does not override the newly reproduced failures.
